### PR TITLE
Disable clang-format and gersemi since its not working properly

### DIFF
--- a/.github/workflows/pr-pull.yaml
+++ b/.github/workflows/pr-pull.yaml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   check-format:
     name: Check Formatting 🔍
+    if: false
     uses: ./.github/workflows/check-format.yaml
     permissions:
       contents: read

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   check-format:
     name: Check Formatting 🔍
-    if: github.ref_name == 'master' || github.ref_name == 'main'
+    if: false  && (github.ref_name == 'master' || github.ref_name == 'main')
     uses: ./.github/workflows/check-format.yaml
     permissions:
       contents: read


### PR DESCRIPTION
For now its not working. Disabled for now, might add it back later.

In path `.github\actions\run-clang-format\action.yaml`

```
ls -la ./build-aux/
chmod +x ./build-aux/run-clang-format
chmod +x ./build-aux/run-cmake-format
chmod +x ./build-aux/run-swift-format
chmod +x ./build-aux/.run-format.zsh
./build-aux/run-clang-format --fail-${{ inputs.failCondition }} --check ${changes}
```

I get the following error:
```
./build-aux/run-clang-format: 1: .run-format.zsh: not found
```
