### PR TITLE
Fix replay buffer segment overlap and add GitHub Actions CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,45 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:  # also allows manual trigger from GitHub UI
+
+jobs:
+  build-windows:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup OBS deps
+        uses: obsproject/obs-deps@v1.1.0
+        with:
+          path: ${{ github.workspace }}/obs-deps
+
+      - name: Configure
+        shell: pwsh
+        run: |
+          cmake -S . -B build `
+            -G "Visual Studio 17 2022" `
+            -A x64 `
+            -DCMAKE_PREFIX_PATH="${{ github.workspace }}/obs-deps"
+
+      - name: Build
+        run: cmake --build build --config RelWithDebInfo
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: obs-fightrecoder-windows
+          path: build/RelWithDebInfo/obs-fightrecorder.dll
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: build/RelWithDebInfo/obs-fightrecorder.dll
+          generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch:  # also allows manual trigger from GitHub UI
+  workflow_dispatch:
 
 jobs:
   build-windows:
@@ -15,18 +15,9 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup OBS deps
-        uses: obsproject/obs-deps@v1.1.0
-        with:
-          path: ${{ github.workspace }}/obs-deps
-
       - name: Configure
         shell: pwsh
-        run: |
-          cmake -S . -B build `
-            -G "Visual Studio 17 2022" `
-            -A x64 `
-            -DCMAKE_PREFIX_PATH="${{ github.workspace }}/obs-deps"
+        run: cmake -S . -B build -G "Visual Studio 17 2022" -A x64
 
       - name: Build
         run: cmake --build build --config RelWithDebInfo
@@ -34,7 +25,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: obs-fightrecoder-windows
+          name: obs-fightrecorder-windows
           path: build/RelWithDebInfo/obs-fightrecorder.dll
 
       - name: Create Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-windows:
     runs-on: windows-2022
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,15 +22,25 @@ jobs:
       - name: Build
         run: cmake --build build --config RelWithDebInfo
 
+      - name: Find built DLL
+        shell: pwsh
+        run: |
+          $dll = Get-ChildItem -Path build -Recurse -Filter "obs-fightrecorder.dll" | Select-Object -First 1
+          if (-not $dll) {
+            throw "obs-fightrecorder.dll not found in build output"
+          }
+          Copy-Item $dll.FullName -Destination $env:GITHUB_WORKSPACE\obs-fightrecorder.dll
+          Write-Host "Found DLL at: $($dll.FullName)"
+
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: obs-fightrecorder-windows
-          path: build/RelWithDebInfo/obs-fightrecorder.dll
+          path: obs-fightrecorder.dll
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: build/RelWithDebInfo/obs-fightrecorder.dll
+          files: obs-fightrecorder.dll
           generate_release_notes: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ project(${_name} VERSION ${_version})
 
 
 
-option(ENABLE_FRONTEND_API "Use obs-frontend-api for UI functionality" OFF)
+option(ENABLE_FRONTEND_API "Use obs-frontend-api for UI functionality" ON)
 option(ENABLE_QT "Use Qt functionality" OFF)
 
 include(compilerconfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,10 +26,26 @@ include(helpers)
 
 add_library(${CMAKE_PROJECT_NAME} MODULE)
 
+# Find FFmpeg libraries from obs-deps (works in CI and local builds)
+find_library(AVFORMAT_LIB avformat PATHS ${CMAKE_PREFIX_PATH} PATH_SUFFIXES lib NO_DEFAULT_PATH)
+find_library(AVUTIL_LIB avutil PATHS ${CMAKE_PREFIX_PATH} PATH_SUFFIXES lib NO_DEFAULT_PATH)
+find_library(AVCODEC_LIB avcodec PATHS ${CMAKE_PREFIX_PATH} PATH_SUFFIXES lib NO_DEFAULT_PATH)
+
+# Fallback to original behavior for local builds with CMAKE_LIBRARY_PATH set
+if(NOT AVFORMAT_LIB)
+    set(AVFORMAT_LIB "${CMAKE_LIBRARY_PATH}/avformat.lib")
+endif()
+if(NOT AVUTIL_LIB)
+    set(AVUTIL_LIB "${CMAKE_LIBRARY_PATH}/avutil.lib")
+endif()
+if(NOT AVCODEC_LIB)
+    set(AVCODEC_LIB "${CMAKE_LIBRARY_PATH}/avcodec.lib")
+endif()
+
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE 
-    "${CMAKE_LIBRARY_PATH}/avformat.lib"
-    "${CMAKE_LIBRARY_PATH}/avutil.lib"
-    "${CMAKE_LIBRARY_PATH}/avcodec.lib")
+    ${AVFORMAT_LIB}
+    ${AVUTIL_LIB}
+    ${AVCODEC_LIB})
 
 find_package(libobs REQUIRED)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE OBS::libobs)

--- a/cmake/common/buildspec_common.cmake
+++ b/cmake/common/buildspec_common.cmake
@@ -94,14 +94,9 @@ function(_setup_obs_studio)
   message(STATUS "Build ${label} (${arch}) - done")
 
   message(STATUS "Install ${label} (${arch})")
-  if(OS_WINDOWS)
-    set(_cmake_extra "--component obs_libraries")
-  else()
-    set(_cmake_extra "")
-  endif()
   execute_process(
-    COMMAND "${CMAKE_COMMAND}" --install build_${arch} --component Development --config Debug --prefix
-            "${dependencies_dir}" ${_cmake_extra}
+    COMMAND "${CMAKE_COMMAND}" --install build_${arch} --config Debug --prefix
+            "${dependencies_dir}"
     WORKING_DIRECTORY "${dependencies_dir}/${_obs_destination}"
     RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY
     OUTPUT_QUIET)

--- a/cmake/common/buildspec_common.cmake
+++ b/cmake/common/buildspec_common.cmake
@@ -94,12 +94,29 @@ function(_setup_obs_studio)
   message(STATUS "Build ${label} (${arch}) - done")
 
   message(STATUS "Install ${label} (${arch})")
-  execute_process(
-    COMMAND "${CMAKE_COMMAND}" --install build_${arch} --config Debug --prefix
-            "${dependencies_dir}"
-    WORKING_DIRECTORY "${dependencies_dir}/${_obs_destination}"
-    RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY
-    OUTPUT_QUIET)
+  if(OS_WINDOWS)
+    # Install runtime DLLs
+    execute_process(
+      COMMAND "${CMAKE_COMMAND}" --install build_${arch} --component obs_libraries --config Debug --prefix
+              "${dependencies_dir}"
+      WORKING_DIRECTORY "${dependencies_dir}/${_obs_destination}"
+      RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY
+      OUTPUT_QUIET)
+    # Install CMake config files, headers, and import libs
+    execute_process(
+      COMMAND "${CMAKE_COMMAND}" --install build_${arch} --component Development --config Debug --prefix
+              "${dependencies_dir}"
+      WORKING_DIRECTORY "${dependencies_dir}/${_obs_destination}"
+      RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY
+      OUTPUT_QUIET)
+  else()
+    execute_process(
+      COMMAND "${CMAKE_COMMAND}" --install build_${arch} --component Development --config Debug --prefix
+              "${dependencies_dir}"
+      WORKING_DIRECTORY "${dependencies_dir}/${_obs_destination}"
+      RESULT_VARIABLE _process_result COMMAND_ERROR_IS_FATAL ANY
+      OUTPUT_QUIET)
+  endif()
   message(STATUS "Install ${label} (${arch}) - done")
 endfunction()
 

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -149,6 +149,15 @@ void stop_recording()
 	if (fightrecorder->started_recording) {
 		obs_frontend_recording_stop();
 		blog(LOG_DEBUG, "obs-fightrecorder stopped recording");
+
+		/* Clear the replay buffer so the next fight doesn't
+		 * inherit footage from this one. */
+		if (obs_frontend_replay_buffer_active()) {
+			obs_frontend_replay_buffer_stop();
+			obs_frontend_replay_buffer_start();
+			blog(LOG_DEBUG,
+			     "obs-fightrecorder restarted replay buffer to prevent overlap");
+		}
 	}
 }
 

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -154,9 +154,28 @@ void stop_recording()
 		 * inherit footage from this one. */
 		if (obs_frontend_replay_buffer_active()) {
 			obs_frontend_replay_buffer_stop();
-			obs_frontend_replay_buffer_start();
+
+			/* Wait briefly for the buffer to fully stop.
+			 * Calling start() while still stopping can fail
+			 * silently, leaving the buffer down until the
+			 * 30-second client check rescues it. */
+			int wait_ms = 0;
+			while (obs_frontend_replay_buffer_active() && wait_ms < 1000) {
+				os_sleep_ms(50);
+				wait_ms += 50;
+			}
+
+			/* Retry start until the buffer is actually active */
+			int retries = 0;
+			while (!obs_frontend_replay_buffer_active() && retries < 10) {
+				obs_frontend_replay_buffer_start();
+				os_sleep_ms(100);
+				retries++;
+			}
+
 			blog(LOG_DEBUG,
-			     "obs-fightrecorder restarted replay buffer to prevent overlap");
+			     "obs-fightrecorder restarted replay buffer (waited %d ms, retries %d)",
+			     wait_ms, retries);
 		}
 	}
 }


### PR DESCRIPTION
Summary of Changes
This PR introduces two main improvements to the project:

    Prevents Overlapping Replay Buffer Segments

        Modifies the recording logic to bounce (stop and restart) the replay buffer immediately after a recording is saved.

        This ensures new recording segments start cleanly, preventing overlapping footage regardless of the user's buffer settings. This improves reliability and the quality of saved clips.

    Adds Automated Build Workflow (CI/CD)

        Adds/modifies build configuration files to enable automated builds via GitHub Actions.

        With this change, the plugin DLL can now be built directly through GitHub's workflows, eliminating the need for contributors or users to set up a local Visual Studio environment to produce a usable binary.

Motivation & Impact

    The buffer bounce fixes a core functionality issue where segments could overlap, leading to corrupted or duplicate footage.

    The CI/CD setup streamlines the contribution process and makes it easier for users to access the latest DLL builds directly from the Actions tab, lowering the barrier to testing.

Testing

    I have tested the replay buffer changes and confirmed no overlapping segments occur with various buffer size configurations.
    The GitHub Actions workflow completes successfully, producing a valid DLL artifact.